### PR TITLE
Sanitize number before conversion

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -984,7 +984,7 @@
                         }
                     }
                     if ($.inArray($this.prop('tagName').toLowerCase(), settings.tagList) !== -1 && $this.text() !== '') {
-                        $this.autoNumeric('set', $this.text());
+                        $this.autoNumeric('set', $this.text().replace(/(?:\r\n|\r|\n)\s+/g, ''));
                     }
                 }
                 settings.runOnce = true;

--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -984,7 +984,7 @@
                         }
                     }
                     if ($.inArray($this.prop('tagName').toLowerCase(), settings.tagList) !== -1 && $this.text() !== '') {
-                        $this.autoNumeric('set', $this.text().replace(/(?:\r\n|\r|\n)\s+/g, ''));
+                        $this.autoNumeric('set', $this.text().trim());
                     }
                 }
                 settings.runOnce = true;

--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -2,7 +2,7 @@
  * autoNumeric.js
  * @author: Bob Knothe
  * @author: Sokolov Yura
- * @version: 1.9.46 - 2016-09-11 GMT 10:00 PM / 22:00
+ * @version: 1.9.47 - 2016-09-11 GMT 10:00 PM / 22:00
  *
  * Created by Robert J. Knothe on 2010-10-25. Please report any bugs to https://github.com/BobKnothe/autoNumeric
  * Contributor by Sokolov Yura on 2010-11-07

--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -2,7 +2,7 @@
  * autoNumeric.js
  * @author: Bob Knothe
  * @author: Sokolov Yura
- * @version: 1.9.47 - 2016-09-11 GMT 10:00 PM / 22:00
+ * @version: 1.9.47 - 2019-04-16 6h03 UTC
  *
  * Created by Robert J. Knothe on 2010-10-25. Please report any bugs to https://github.com/BobKnothe/autoNumeric
  * Contributor by Sokolov Yura on 2010-11-07


### PR DESCRIPTION
Using `autoNumeric` in templates formed with spaces and/or new lines in the number formation, such as: 
```
<td data-object='currency'>
    123456
</td>
```
produces an output, such as: `$0,123,456.00` instead of `$123,456.00`
However, the node, formed as:
```
<td data-object='currency'>123456</td>
```
Produces correct output: `$123,456.00` as expected.

This issue happens only to elements that are non-input based.
